### PR TITLE
Fixed missing_header in createSigner

### DIFF
--- a/src/com/eka/middleware/pub/util/auth/AWSHeaders.java
+++ b/src/com/eka/middleware/pub/util/auth/AWSHeaders.java
@@ -28,9 +28,10 @@ public class AWSHeaders {
         String contentLengthHeader = "content-length";
         String contentHashString = AWS4SignerBase.EMPTY_BODY_SHA256;
         if ((payload == null || payload.length == 0)) {
-            if (null == queryParameters || queryParameters.isEmpty()) {
-                awsHeaders.put("x-amz-content-sha256", AWS4SignerBase.EMPTY_BODY_SHA256);
-            }
+            awsHeaders.put("x-amz-content-sha256", AWS4SignerBase.EMPTY_BODY_SHA256);
+//            if (null == queryParameters || queryParameters.isEmpty()) {
+//                awsHeaders.put("x-amz-content-sha256", AWS4SignerBase.EMPTY_BODY_SHA256);
+//            }
 
         } else {
             byte[] contentHash = AWS4SignerBase.hash(payload);


### PR DESCRIPTION
*MissingHeader-x-amz-content-sha256
for requests with no payload but queryParameters